### PR TITLE
#9, fix nalanda bug.  Moved modifier context from city-state to game

### DIFF
--- a/BetterBalancedGame.modinfo
+++ b/BetterBalancedGame.modinfo
@@ -1,5 +1,5 @@
 <!-- BETA ModID -->
-<Mod id="cb84074d-5007-4207-b662-c35a5f7be220" version="40106">
+<Mod id="cb84074d-5007-4207-b662-c35a5f7be230" version="40107">
 <!-- Codenaugh's ModID
 <Mod id="cb84074d-5007-4207-b662-c35a5f7be217" version="4003">
 -->

--- a/sql/new_bbg_nfp_babylon.sql
+++ b/sql/new_bbg_nfp_babylon.sql
@@ -11,3 +11,40 @@ INSERT INTO ModifierArguments(ModifierId, Name, Value, Extra) VALUES
 DELETE FROM TraitModifiers WHERE TraitType='TRAIT_CIVILIZATION_BABYLON' AND ModifierID='TRAIT_EUREKA_INCREASE';
 INSERT INTO TraitModifiers(TraitType, ModifierID) VALUES
     ('TRAIT_CIVILIZATION_BABYLON', 'BBG_TRAIT_BABYLON_EUREKA');
+
+
+
+-- Babylon - Nalanda infinite technology re-suze fix.
+-- Remove the trait modifier from the Nalanda Minor
+--  This was the initial cause of the problem.  
+--   The context was destroyed when suzerain was lost, and recreated when suzerain was gained.  
+--   Moving the context to the Game instance solves this problem.
+DELETE FROM TraitModifiers WHERE ModifierId="MINOR_CIV_NALANDA_FREE_TECHNOLOGY";
+
+-- We don't care about these modifiers anymore, they are connected to the TraitModifier
+DELETE FROM Modifiers WHERE ModifierId="MINOR_CIV_NALANDA_FREE_TECHNOLOGY_MODIFIER";
+DELETE FROM Modifiers WHERE ModifierId="MINOR_CIV_NALANDA_FREE_TECHNOLOGY";
+
+-- Attach the modifier to check for improvement to each player
+INSERT INTO Modifiers 
+	(ModifierId, ModifierType)
+	VALUES
+	('MINOR_CIV_NALANDA_MAHAVIHARA', "MODIFIER_ALL_PLAYERS_ATTACH_MODIFIER");
+
+-- Modifier to actually check if the improvement is built, only done once
+INSERT INTO Modifiers 
+	(ModifierId, ModifierType, OwnerRequirementSetId, RunOnce, Permanent)
+	VALUES
+	('MINOR_CIV_NALANDA_MAHAVIHARA_TECH_ON_FIRST_BUILD', "MODIFIER_PLAYER_GRANT_RANDOM_TECHNOLOGY", "PLAYER_HAS_MAHAVIHARA", 1, 1);
+
+INSERT INTO ModifierArguments
+    (ModifierId, Name, Type, Value)
+    VALUES
+    ('MINOR_CIV_NALANDA_MAHAVIHARA', 'ModifierId', 'ARGTYPE_IDENTITY', 'MINOR_CIV_NALANDA_MAHAVIHARA_TECH_ON_FIRST_BUILD'),
+    ('MINOR_CIV_NALANDA_MAHAVIHARA_TECH_ON_FIRST_BUILD', 'Amount', 'ARGTYPE_IDENTITY', 1);
+
+-- Modifier which triggers and attaches to all players when game is created 
+INSERT INTO GameModifiers
+    (ModifierId)
+    VALUES
+    ('MINOR_CIV_NALANDA_MAHAVIHARA');


### PR DESCRIPTION
Bug Behavior Unfixed: https://www.youtube.com/watch?v=41fQLQ5-fCI&feature=youtu.be
Fixed Behavior: https://www.youtube.com/watch?v=mO9Pp1ut2-c&feature=youtu.be

Issue #9 allows the Player to suze/unsuze with instant Amani re-establishment on the same turn.  This triggered the Modifier
![image](https://user-images.githubusercontent.com/807352/100544869-ff7fab80-3258-11eb-8b98-690064b7dcae.png)
The root issue seems to be that the `Modifier` is a `TraitModifier`

Due to this, the context for this Modifier is lost when the Player loses Suzerain status.  Therefore the `RunOnce` and `Permanent` flags from
![image](https://user-images.githubusercontent.com/807352/100544886-1b834d00-3259-11eb-8384-d13dfd8e3bab.png)
are lost and have no effect.

This fix moves the `Modifier` context to be owned by the `Game` instance. Each player then gets a modifier which exists for the duration of the game and can only be satisfied once per-player.

No suzerain check is made, only that the improvement is built (which implicitly requires suzerain status)