### PR TITLE
#1, Fixed HOLY_WATER behavior.  Applies only once per founder, per unit now

### DIFF
--- a/sql/xp2__gathering_storm.sql
+++ b/sql/xp2__gathering_storm.sql
@@ -346,17 +346,29 @@ UPDATE BeliefModifiers SET ModifierID='WORLD_CHURCH_CULTURE_FOREIGN_FOLLOWER' WH
 UPDATE Beliefs SET Description='LOC_BELIEF_CROSS_CULTURAL_DIALOGUE_DESCRIPTION' WHERE BeliefType='BELIEF_CROSS_CULTURAL_DIALOGUE';
 UPDATE Beliefs SET Description='LOC_BELIEF_WORLD_CHURCH_DESCRIPTION' WHERE BeliefType='BELIEF_WORLD_CHURCH';
 UPDATE Beliefs SET Description='LOC_BELIEF_LAY_MINISTRY_DESCRIPTION' WHERE BeliefType='BELIEF_LAY_MINISTRY';
+
+----------- HOLY WATER --------------
 -- holy waters affects mili units instead of religious, and works in all converted city tiles
+-- 2020-12-03 was previously affecting all districts
+
+-- We attach HOLY_WATERS_HEALING to all players that satisfy  REQUIRES_PLAYER_FOUNDED_RELIGION
+UPDATE Modifiers SET ModifierType='MODIFIER_ALL_PLAYERS_ATTACH_MODIFIER' WHERE ModifierId='HOLY_WATERS_HEALING';
+
+-- This modifier is then applied which applies to all of the founding players units
 UPDATE Modifiers SET ModifierType='MODIFIER_PLAYER_UNITS_ADJUST_HEAL_PER_TURN' WHERE ModifierId='HOLY_WATERS_HEALING_MODIFIER';
+
 DELETE FROM RequirementSetRequirements WHERE RequirementSetId='HOLY_WATERS_HEALING_REQUIREMENTS';
 DELETE FROM RequirementSetRequirements WHERE RequirementSetId='HOLY_WATERS_HEALING_MODIFIER_REQUIREMENTS';
 INSERT OR IGNORE INTO RequirementSetRequirements VALUES
 	('HOLY_WATERS_HEALING_REQUIREMENTS', 'REQUIRES_PLAYER_FOUNDED_RELIGION'),
 	('HOLY_WATERS_HEALING_MODIFIER_REQUIREMENTS', 'REQUIRES_UNIT_NEAR_FRIENDLY_RELIGIOUS_CITY'),
 	('HOLY_WATERS_HEALING_MODIFIER_REQUIREMENTS', 'REQUIRES_UNIT_NEAR_ENEMY_RELIGIOUS_CITY');
-UPDATE RequirementSets SET RequirementSetType='REQUIREMENTSET_TEST_ANY' WHERE RequirementSetId='HOLY_WATERS_HEALING_MODIFIER_REQUIREMENTS';
-UPDATE ModifierArguments SET Value='5' WHERE ModifierId='HOLY_WATERS_HEALING_MODIFIER' AND Name='Amount';
 
+-- Inclusion test in Friendly or Enemy converted territory (happens per unit)
+UPDATE RequirementSets SET RequirementSetType='REQUIREMENTSET_TEST_ANY' WHERE RequirementSetId='HOLY_WATERS_HEALING_MODIFIER_REQUIREMENTS';
+
+-- Updated this value to match the description text
+UPDATE ModifierArguments SET Value='10' WHERE ModifierId='HOLY_WATERS_HEALING_MODIFIER' AND Name='Amount';
 
 --==============================================================
 --******				START BIASES					  ******


### PR DESCRIPTION
[BUG BEHAVIOR]
This was previously a +5 bonus being applied to all districts, as seen in the `Expansion2_beliefs.xml`
![image](https://user-images.githubusercontent.com/807352/101012751-92735b00-3563-11eb-90a3-666d124e2ed0.png)
This was the cause of the "full heal" experienced and reported. ( seen in #1 )

[FIXED]
Here is an excerpt showing the `Modifier` structure.  
`HOLY_WATER_HEALING` - owned by "Holy Waters"
`HOLY_WATER_MODIFIER` - owned by the Founder of "Holy Waters", applied to all mili units owned by the founder
![image](https://user-images.githubusercontent.com/807352/101012490-36103b80-3563-11eb-90d3-9cc20b43e52e.png)

- Apply to the founder
- Apply to the founders units
- Change the modifier from +5 to +10 as originally intended
