### PR TITLE
#21, Civilians now immune to MOST disaster/random events

### DIFF
--- a/sql/xp2__gathering_storm.sql
+++ b/sql/xp2__gathering_storm.sql
@@ -453,6 +453,35 @@ UPDATE Feature_YieldChanges SET YieldChange='3' WHERE FeatureType='FEATURE_CHOCO
 UPDATE Feature_YieldChanges SET YieldChange='1' WHERE FeatureType='FEATURE_CHOCOLATEHILLS' AND YieldType='YIELD_SCIENCE'   ;
 UPDATE Feature_AdjacentYields SET YieldChange='2' WHERE FeatureType='FEATURE_DEVILSTOWER' AND YieldType='YIELD_FAITH';
 
+--==============================================================
+--******			D I S A S T E R S       			  ******
+--==============================================================
+
+-- Revert exceptions
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_BLIZZARD_CRIPPLING';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_BLIZZARD_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_DUST_STORM_HABOOB';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_DUST_STORM_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_EYJAFJALLAJOKULL_CATASTROPHIC';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_EYJAFJALLAJOKULL_MEGACOLOSSAL';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_EYJAFJALLAJOKULL_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_FLOOD_1000_YEAR';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_FLOOD_MAJOR';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_FLOOD_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_FOREST_FIRE';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_FOREST_FIRE_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_HURRICANE_CAT_5';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_JUNGLE_FIRE';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_JUNGLE_FIRE_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_KILIMANJARO_CATASTROPHIC';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_KILIMANJARO_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_TORNADO_OUTBREAK';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_VESUVIUS_MEGACOLOSSAL';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_VESUVIUS_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_VOLCANO_CATASTROPHIC';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_VOLCANO_MEGACOLOSSAL';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_VOLCANO_TRIGGERED';
+
 
 
 --==============================================================

--- a/sql/xp2__gathering_storm.sql
+++ b/sql/xp2__gathering_storm.sql
@@ -458,29 +458,29 @@ UPDATE Feature_AdjacentYields SET YieldChange='2' WHERE FeatureType='FEATURE_DEV
 --==============================================================
 
 -- Revert exceptions
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_BLIZZARD_CRIPPLING';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_BLIZZARD_TRIGGERED';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_DUST_STORM_HABOOB';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_DUST_STORM_TRIGGERED';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_EYJAFJALLAJOKULL_CATASTROPHIC';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_EYJAFJALLAJOKULL_MEGACOLOSSAL';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_EYJAFJALLAJOKULL_TRIGGERED';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_FLOOD_1000_YEAR';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_FLOOD_MAJOR';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_FLOOD_TRIGGERED';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_FOREST_FIRE';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_FOREST_FIRE_TRIGGERED';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_HURRICANE_CAT_5';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_JUNGLE_FIRE';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_JUNGLE_FIRE_TRIGGERED';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_KILIMANJARO_CATASTROPHIC';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_KILIMANJARO_TRIGGERED';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_TORNADO_OUTBREAK';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_VESUVIUS_MEGACOLOSSAL';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_VESUVIUS_TRIGGERED';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_VOLCANO_CATASTROPHIC';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_VOLCANO_MEGACOLOSSAL';
-UPDATE RandomEvent_Damages Set Percentage=0 WHERE RandomEventType='RANDOM_EVENT_VOLCANO_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_DUST_STORM_HABOOB';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_BLIZZARD_CRIPPLING';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_BLIZZARD_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_DUST_STORM_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_EYJAFJALLAJOKULL_CATASTROPHIC';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_EYJAFJALLAJOKULL_MEGACOLOSSAL';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_EYJAFJALLAJOKULL_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_FLOOD_1000_YEAR';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_FLOOD_MAJOR';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_FLOOD_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_FOREST_FIRE';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_FOREST_FIRE_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_HURRICANE_CAT_5';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_JUNGLE_FIRE';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_JUNGLE_FIRE_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_KILIMANJARO_CATASTROPHIC';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_KILIMANJARO_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_TORNADO_OUTBREAK';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_VESUVIUS_MEGACOLOSSAL';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_VESUVIUS_TRIGGERED';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_VOLCANO_CATASTROPHIC';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_VOLCANO_MEGACOLOSSAL';
+UPDATE RandomEvent_Damages Set Percentage=0 WHERE DamageType='UNIT_KILLED_CIVILIAN' AND RandomEventType='RANDOM_EVENT_VOLCANO_TRIGGERED';
 
 
 


### PR DESCRIPTION
**Unaffected Disaster Types (these types still kill civilians):** 
- Nuclear Accidents
- Comet Strikes

**Values before the change:**
![BEFOREKilledCivilian](https://user-images.githubusercontent.com/807352/101165409-e602a900-3636-11eb-82fa-5c8e225a7f08.PNG)

**Values after the change:**
![AFTERKilledCivilian](https://user-images.githubusercontent.com/807352/101165407-e56a1280-3636-11eb-9199-8ed19ba10e7b.PNG)

There is not fantastic transparency into what unit types `DamageType="UNIT_KILLED_CIVILIAN"` actually entails, but we can reasonably assume this list is somewhat accurate.
![image](https://user-images.githubusercontent.com/807352/101166072-fa937100-3637-11eb-8a95-eb65b0f6366e.png)

Our main goal is to prevent Settlers and Builders from being RNG'd to death by disasters.  This PR should achieve that.  
AFAIK: Traders are immune beyond our control based on discovery during this work.

Video showing behavior of Fires vs. Settlers:
https://www.youtube.com/watch?v=pNhnO1Cvoys