### PR TITLE
[HOTFIX] Warcart 28->26str, 45->55prod, +4 vs. barbs + translations

### DIFF
--- a/BetterBalancedGame.modinfo
+++ b/BetterBalancedGame.modinfo
@@ -12,7 +12,7 @@
 			Live build of Better Balanced Game.
 		</Description>
 		<Teaser>Mods to balance Civ Players League multiplayer games</Teaser>
-		<Authors>iElden, D. / Jack The Narrator, codenaugh</Authors>
+		<Authors>iElden, D. / Jack The Narrator, codenaugh, MarsLife(puj)</Authors>
 		<SpecialThanks>coloo, abstr, priz, seed.of.apricot, Klas, fl0r3k, WhySoHate, wazabaza, WhySoHate, Ignasiuz</SpecialThanks>
 		<CompatibleVersions>2.0</CompatibleVersions>
 	</Properties>

--- a/lang/chinese.xml
+++ b/lang/chinese.xml
@@ -113,6 +113,9 @@
 		<Replace Tag="LOC_UNIT_SUMERIAN_WAR_CART_DESCRIPTION" Language="zh_Hans_CN">
 			<Text>苏美尔古典时代特色单位，取代重型战车，在科技“骑马”解锁。有几率俘获击败的城邦单位。对站抗骑兵单位，无减益。如果该单位从开阔地形开始回合，+1 [ICON_Movement] 移动力。</Text>
 		</Replace>
+		<Replace Tag="LOC_ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_DESCRIPTION_BBG" Language="zh_Hans_CN">
+			<Text>同蛮族战斗时，+4 [ICON_Strength] 单位战斗力。</Text>
+		</Replace>
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_EJERCITO_PATRIOTA_DESCRIPTION" Language="zh_Hans_CN">
 			<Text>所有单位+1视野. 升级轻骑兵单位不会结束其回合。</Text>
 		</Replace>

--- a/lang/english.xml
+++ b/lang/english.xml
@@ -976,6 +976,9 @@
 		<Replace Tag="LOC_TRAIT_LEADER_ADVENTURES_ENKIDU_EXPANSION2_DESCRIPTION" Language="en_US">
 			<Text>+25% Experience for all units. [NEWLINE]Starts with a War-Cart for the Ancient Era.[NEWLINE]When you capture a Barbarian Outpost, receive a Tribal Village reward in addition to the usual [ICON_Gold] Gold. Pay half the usual cost to levy city-state units.</Text>
 		</Replace>
+		<Replace Tag="LOC_ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_DESCRIPTION_BBG" Language="en_US">
+			<Text>+4 [ICON_Strength] Unit Combat Strength when fighting Barbarians.</Text>
+		</Replace>
 		
 		
 		<Replace Tag="LOC_PROJECT_ECOURT_FESTIVAL_DESCRIPTION" Language="en_US">

--- a/lang/french.xml
+++ b/lang/french.xml
@@ -516,6 +516,9 @@
 		<Replace Tag="LOC_IMPROVEMENT_ZIGGURAT_DESCRIPTION" Language="fr_FR">
 			<Text>[COLOR_RED]To Translate :[ENDCOLOR]Unlocks the Builder ability to construct a Ziggurat, unique to Sumeria.[NEWLINE][NEWLINE]+1 [ICON_Housing] Housing.+2 [ICON_Science] Science. +1 [ICON_Culture] Culture if next to River. +1 [ICON_Faith] Faith if next to a District or Two Farms. [NEWLINE]Cannot be built on Hills or Adjacent to another Ziggurat.</Text>
 		</Replace>
+		<Replace Tag="LOC_ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_DESCRIPTION_BBG" Language="fr_FR">
+			<Text>[ICON_Strength] Puissance de combat +4 contre les barbares.</Text>
+		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_ADVENTURES_ENKIDU_NAME" Language="fr_FR">
 			<Text>[COLOR_RED]To Translate :[ENDCOLOR]Shūtur eli sharrī</Text>
 		</Replace>

--- a/lang/german.xml
+++ b/lang/german.xml
@@ -206,6 +206,9 @@
 		<Replace Tag="LOC_IMPROVEMENT_ZIGGURAT_DESCRIPTION" Language="de_DE">
 			<Text>[COLOR_RED]To Translate :[ENDCOLOR]Unlocks the Builder ability to construct a Ziggurat, unique to Sumeria.[NEWLINE][NEWLINE]+1 [ICON_Housing] Housing.+2 [ICON_Science] Science. +1 [ICON_Culture] Culture if next to River. +1 [ICON_Faith] Faith if next to a District or Two Farms. [NEWLINE]Cannot be built on Hills or Adjacent to another Ziggurat.</Text>
 		</Replace>
+		<Replace Tag="LOC_ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_DESCRIPTION_BBG" Language="de_DE">
+			<Text>+4 [ICON_Strength] Kampfstärke gegen Barbaren.</Text>
+		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_ADVENTURES_ENKIDU_NAME" Language="de_DE">
 			<Text>[COLOR_RED]To Translate :[ENDCOLOR]Shūtur eli sharrī</Text>
 		</Replace>

--- a/lang/korean.xml
+++ b/lang/korean.xml
@@ -115,6 +115,9 @@
 			<Text>중전차를 대체하는 수메르 특유의 고전 시대 유닛입니다. 기마술 연구완료시 생산할 수 있습니다. 처치한 도시 국가 유닛을 일정한 확률로 포획합니다. 대기병 유닛과 전투할 때 페널티가 없습니다. 평지 지형에서 턴을 시작하는 경우 [ICON_Movement] 이동력 +1을 받습니다.</Text>
 		</Replace>
 		-->
+		<Replace Tag="LOC_ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_DESCRIPTION_BBG" Language="ko_KR">
+			<Text>야만인과 전투 시 [ICON_Strength] 유닛 전투력 +4.</Text>
+		</Replace>
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_EJERCITO_PATRIOTA_DESCRIPTION" Language="ko_KR">
 			<Text>모든 유닛에게 시야 +1을 부여합니다. 경기병 유닛을 진급시킬 때 해당 유닛의 턴이 끝나지 않습니다.</Text>
 		</Replace>

--- a/lang/polish.xml
+++ b/lang/polish.xml
@@ -535,6 +535,9 @@
 		<Replace Tag="LOC_IMPROVEMENT_ZIGGURAT_DESCRIPTION" Language="pl_PL">
 			<Text>[COLOR_RED]To Translate :[ENDCOLOR]Unlocks the Builder ability to construct a Ziggurat, unique to Sumeria.[NEWLINE][NEWLINE]+1 [ICON_Housing] Housing.+2 [ICON_Science] Science. +1 [ICON_Culture] Culture if next to River. +1 [ICON_Faith] Faith if next to a District or Two Farms. [NEWLINE]Cannot be built on Hills or Adjacent to another Ziggurat.</Text>
 		</Replace>
+		<Replace Tag="LOC_ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_DESCRIPTION_BBG" Language="pl_PL">
+			<Text>+4 do [ICON_Strength] siły bojowej jednostki podczas walki z barbarzyńcami.</Text>
+		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_ADVENTURES_ENKIDU_NAME" Language="pl_PL">
 			<Text>[COLOR_RED]To Translate :[ENDCOLOR]Shūtur eli sharrī</Text>
 		</Replace>

--- a/sql/new_bbg_sumer.sql
+++ b/sql/new_bbg_sumer.sql
@@ -79,10 +79,34 @@ VALUES	('Ziggurat_Faith_Farm',			'Placeholder',	'YIELD_FAITH',		1,				2,				'IMP
 		('Ziggurat_Faith_District',		'Placeholder',	'YIELD_FAITH',		1,				1,				NULL,					1);
 
 
--- Sumerian War Carts are nerfed to 28 (BASE = 30)
-UPDATE Units SET Combat=28 WHERE UnitType='UNIT_SUMERIAN_WAR_CART';
--- Sumerian War Carts are cost is dimished to 45 (BASE = 55)
-UPDATE Units SET Cost=45 WHERE UnitType='UNIT_SUMERIAN_WAR_CART';	
+-- Sumerian War Carts are nerfed to 26 (BASE = 30)
+-- 20-12-07 Hotfix: Nerf from 28->26
+UPDATE Units SET Combat=26 WHERE UnitType='UNIT_SUMERIAN_WAR_CART';
+-- Sumerian War Carts are cost is dimished to 55 (BASE = 55)
+-- 20-12-07 Hotfix: Revert to 55 cost
+UPDATE Units SET Cost=55 WHERE UnitType='UNIT_SUMERIAN_WAR_CART';	
 
+
+-- 20-12-07 Hotfix: Increase war-cart strength vs. barbs
+INSERT OR IGNORE INTO Types (Type, Kind) VALUES
+	('ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_BBG', 'KIND_ABILITY');
+INSERT OR IGNORE INTO TypeTags VALUES
+	('ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_BBG' ,'CLASS_WAR_CART');
+INSERT OR IGNORE INTO UnitAbilities (UnitAbilityType, Name, Description, Inactive) VALUES
+	('ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_BBG', 'LOC_ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_NAME_BBG', 'LOC_ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_DESCRIPTION_BBG', 0);
+INSERT OR IGNORE INTO UnitAbilityModifiers VALUES
+	('ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_BBG', 'WAR_CART_COMBAT_STRENGTH_VS_BARBS_BBG');
+
+INSERT OR IGNORE INTO Modifiers
+		(ModifierId, ModifierType, SubjectRequirementSetId)
+VALUES	('WAR_CART_COMBAT_STRENGTH_VS_BARBS_BBG','MODIFIER_UNIT_ADJUST_COMBAT_STRENGTH', 'REQUIREMENTS_OPPONENT_IS_BARBARIAN');
+
+INSERT OR IGNORE INTO ModifierStrings
+		(ModifierId, Context, Text)
+VALUES	('WAR_CART_COMBAT_STRENGTH_VS_BARBS_BBG','Preview', 'LOC_ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_DESCRIPTION_BBG');
+
+INSERT INTO ModifierArguments
+		(ModifierId, Name, Value)
+VALUES	('WAR_CART_COMBAT_STRENGTH_VS_BARBS_BBG', 'Amount', 4);
 
 -- Sumerian War Carts as a starting unit in Ancient is coded on the lua front


### PR DESCRIPTION
Sumeria War-Cart Hotfix
Combat Strength: 28=>26
Production Cost: 45=>55
[NEW] +4 vs. Barbs

![AbilityText](https://user-images.githubusercontent.com/807352/101498758-c4722c00-396c-11eb-9141-de13fc3bf64f.PNG)
![AttackPreview](https://user-images.githubusercontent.com/807352/101498761-c5a35900-396c-11eb-95a1-6012df963f0a.PNG)
