### PR TITLE
Fixes #44, Cossacks work as expected with attacking from within borders

### DIFF
--- a/sql/base.sql
+++ b/sql/base.sql
@@ -653,6 +653,11 @@ UPDATE District_GreatPersonPoints SET PointsPerTurn=1 WHERE DistrictType='DISTRI
 --UPDATE ModifierArguments SET Value='2' WHERE ModifierId='TRAIT_INCREASED_TILES';
 -- Cossacks have same base strength as cavalry instead of +5
 UPDATE Units SET Combat=62 WHERE UnitType='UNIT_RUSSIAN_COSSACK';
+
+-- 2020/12/15 - Found in 4.1.2: Fix corner case where Cossacks don't work on borders
+UPDATE Modifiers SET SubjectRequirementSetId=NULL WHERE ModifierId="COSSACK_LOCAL_COMBAT";
+UPDATE Modifiers SET OwnerRequirementSetId="COSSACK_PLOT_IS_OWNER_OR_ADJACENT_REQUIREMENTS" WHERE ModifierId="COSSACK_LOCAL_COMBAT";
+
 -- Lavra district does not acrue Great Person Points unless city has a theater
 UPDATE District_GreatPersonPoints SET PointsPerTurn='0' WHERE DistrictType='DISTRICT_LAVRA' AND GreatPersonClassType='GREAT_PERSON_CLASS_ARTIST';
 UPDATE District_GreatPersonPoints SET PointsPerTurn='0' WHERE DistrictType='DISTRICT_LAVRA' AND GreatPersonClassType='GREAT_PERSON_CLASS_MUSICIAN';


### PR DESCRIPTION
The technical explanation was pretty straightforward. The modifier had the requirement set as a Subject requirement, rather than the Owner requirement (the Cossack itself).

A video of the fixed behavior:
https://youtu.be/fb-8cC0INYw