### PR TITLE
Fixes #48, Corrected Ayutthaya as well as Moksha yields on building c…

### DIFF
--- a/sql/new_bbg_nfp_babylon.sql
+++ b/sql/new_bbg_nfp_babylon.sql
@@ -48,3 +48,25 @@ INSERT INTO GameModifiers
     (ModifierId)
     VALUES
     ('MINOR_CIV_NALANDA_MAHAVIHARA');
+
+
+-- 2020/12/16 - Ayutthaya Culture bug fix
+-- https://github.com/iElden/BetterBalancedGame/issues/48
+
+UPDATE ModifierArguments SET Value=60 WHERE ModifierId="MINOR_CIV_AYUTTHAYA_CULTURE_COMPLETE_BUILDING" AND Name="BuildingProductionPercent";
+UPDATE ModifierArguments SET Value=24 WHERE ModifierId="CARDINAL_CITADEL_OF_GOD_FAITH_FINISH_BUILDINGS" AND Name="BuildingProductionPercent";
+-- Scenario: Building momument on Online speed with 30 production code
+-- BuildingProductionPercent    Faith   Percentage
+-- 0                            0       0%
+-- 1                            180     600%
+-- 6                            30      100%
+-- 10                           18      60% -- Current Ayutthaya 
+-- 17.5                         10.5    35%
+-- 24                           7.5     25% -- Correct Moksha
+-- 25                           7.2     24% -- Current Moksha 
+-- 50                           3.6     12%
+-- 60                           3       10% -- Correct Ayutthaya
+-- 6 * ProductionCost / BuildingProductionPercent = Yield
+-- Therefore =>  
+-- USE THIS FORMULA TO CALCULATE THE DESIRED ((BuildingProductionPercent)) FIELD
+-- BuildingProductionPercent =  ProductionCost * 6 / Yield


### PR DESCRIPTION
`BuildingProductionPercent` Does not work as expected!
Original BuildingProductionPercent: 10
New BuildingProductionPercent: 60
![image](https://user-images.githubusercontent.com/807352/102413745-adc77700-3ff5-11eb-8a84-7bbe2c698c20.png)

This database value is also used with Moksha's "Citadel of God" Promotion 
Original BuildingProductionPercent: 25
New BuildingProductionPercent: 24 
![image](https://user-images.githubusercontent.com/807352/102413890-eebf8b80-3ff5-11eb-8d47-b90041c57581.png)


One would assume (like Firaxis did) that this value is how much of the Building Production Cost should be converted to YIELD.  
I.E. `10% of 40 production = 4 Yield`

However, this is not the case.  There is a formula inside the game engine that handles the `Yield` calculation based on the `BuildingProductionPercent` Test Data Looks like this:
```
NOTE: The below values were tested with a 30 production monument

BuildingProductionPercent    Faith   Percentage
0                            0       0%
1                            180     600%
6                            30      100%
10                           18      60% -- Current Ayutthaya 
17.5                         10.5    35%
24                           7.5     25% -- Correct Moksha
25                           7.2     24% -- Current Moksha 
50                           3.6     12%
60                           3       10% -- Correct Ayutthaya
```

From here we arrive at a formula to calculate `BuildingProductionPercent` based on the the desired `Yield` and `BuildingCost`
`BuildingProductionPercent =  ProductionCost * 6 / Yield`

For a 30 Prod monument, we would want 3 Yield (for 10% culture from production cost).
`BuildingProductionPercent = 30 * 6 / 3`
`BuildingProductionPercent = 60`

For Moksha, the intention was to provide 25% faith. Assume we are building a 32 prod granary.  We would expect a yield of 8.
However, with `BuildingProductionPercent = 25` :
`25= 32 * 6 / Yield` 
`25 * Yield = 32 * 6`
`Yield = 32 * 6 / 25`
we actually get a `Yield` of 7.68, which is what we currently have in the game.  

In conclusion, the Ayutthaya mechanism is the same as Moksha, however Moksha is broken as well!  
The difference between 24% and 25% was so negligible that no one noticed that Moksha was broken 😆 

Here's a video of the Fix in action: https://www.youtube.com/watch?v=LOeM0fBr1i8